### PR TITLE
lookupSymbol on OS X doesn't work

### DIFF
--- a/System/Plugins/DynamicLoader.hs
+++ b/System/Plugins/DynamicLoader.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, MagicHash, UnboxedTuples #-}
+{-# LANGUAGE MagicHash, UnboxedTuples #-}
 ----------------------------------------------------------------------------
 -- |
 -- Module      :  DynamicLoader
@@ -39,6 +39,7 @@ import Foreign.Ptr      (Ptr, nullPtr)
 import Foreign.C.String (CString, withCString, peekCString)
 import System.Directory (getCurrentDirectory, doesFileExist)
 import GHC.Prim
+import System.Info (os)
 
 {-
 
@@ -335,11 +336,7 @@ lookupSymbol qname functionName
 
     -- On OS X all functions have an extra _, at least that
     -- is what people say. Not tested!
-#ifdef __MACOSX__
-    symbolName = "_" ++ moduleName ++ "_" ++ realFunctionName ++ "_closure"
-#else
-    symbolName = moduleName ++ "_" ++ realFunctionName ++ "_closure"
-#endif
+    symbolName = (if os == "darwin" then "_" else "") ++ moduleName ++ "_" ++ realFunctionName ++ "_closure"
 
     encode :: String -> String
     encode str = concatMap encode_ch str


### PR DESCRIPTION
The `__MACOSX__` pre-processor constant wasn't defined for me. Also, I think not using `-XCPP` in Haskell code is a good thing, as it makes code easier to understand, so I replaced it with [`System.Info.os`](https://hackage.haskell.org/package/base-4.8.0.0/docs/System-Info.html#v:os).

It now works for me:

Main.hs:
```
import System.Plugins.DynamicLoader

main = do
	mmodule <- loadModule "Plugin" (Just "tmp") Nothing
	print $ dm_path mmodule
	resolveFunctions
	f <- loadFunction mmodule "run"
	f
```
Plugin.hs:
```
module Plugin where

run = putStrLn "Hello world!"
```

Previously:
```
$ ./test
"tmp/Plugin.o"
test: user error (Could not load symbol: Plugin_run_closure)
```
with this patch:
```
$ ./test
"tmp/Plugin.o"
Hello world!
```