### PR TITLE
Fix DynamicLoader for ghc 7.10.1

### DIFF
--- a/System/Plugins/DynamicLoader.hs
+++ b/System/Plugins/DynamicLoader.hs
@@ -46,6 +46,9 @@ Foreign imports, hooks into the GHC RTS.
 
 -}
 
+foreign import ccall unsafe "initLinker"
+     c_initLinker :: IO ()
+
 foreign import ccall unsafe "loadObj" 
      c_loadObj :: CString -> IO Int
 
@@ -77,7 +80,9 @@ System.Posix.DynamicLinker instead.
 -}
 
 addDLL :: String -> IO ()
-addDLL str = withCString str 
+addDLL str
+    = do c_initLinker
+         withCString str
                (\s -> do err <- c_addDLL s
                          unless (err == nullPtr)
                                 (do msg <- peekCString err
@@ -106,7 +111,9 @@ If it cannot load the object it will throw an exception.
 -}
 loadModule :: String -> Maybe FilePath -> Maybe String -> IO DynamicModule
 loadModule name mpath msuff
-    = do base <- maybe getCurrentDirectory return mpath
+    = do c_initLinker
+
+         base <- maybe getCurrentDirectory return mpath
 
          let qname = split '.' name
              suff  = maybe "o" id msuff
@@ -134,7 +141,8 @@ If it cannot load the object it will throw an exception.
 -}
 loadModuleFromPath :: FilePath -> Maybe FilePath -> IO DynamicModule
 loadModuleFromPath path mbase
-    = do base <- maybe getCurrentDirectory return mbase
+    = do c_initLinker
+         base <- maybe getCurrentDirectory return mbase
 
          qual <- dropIsEq base path
 
@@ -183,7 +191,8 @@ need to resolve functions before you use any functions loaded.
 loadPackage :: String -> Maybe FilePath -> Maybe String -> Maybe String -> 
                IO DynamicPackage
 loadPackage name mpath mpre msuff
-    = do base <- case mpath of
+    = do c_initLinker
+         base <- case mpath of
                             Just a -> return a
                             _      -> getCurrentDirectory
 
@@ -225,7 +234,8 @@ need to resolve functions before you use any functions loaded.
 -}
 loadPackageFromPath :: FilePath -> IO DynamicPackage
 loadPackageFromPath path
-    = do ret <- withCString path c_loadObj
+    = do c_initLinker
+         ret <- withCString path c_loadObj
          unless (ret /= 0) (fail $ "Unable to load package: " ++ path)
 
          let cbits_path = cbitsName path
@@ -253,7 +263,8 @@ any). Throws an exception if any unloading fails.
 -}
 unloadPackage :: DynamicPackage -> IO ()
 unloadPackage (RTP { dp_path = path, dp_cbits = cbits })
-    = do ret <- withCString path c_unloadObj
+    = do c_initLinker
+         ret <- withCString path c_unloadObj
          unless (ret /= 0) (fail $ "Unable to unload package: " ++ path)
          maybe (return ()) unloadPackage cbits
 
@@ -265,7 +276,8 @@ will be thrown.
 -}
 unloadModule :: DynamicModule -> IO ()
 unloadModule (RTM { dm_path = path })
-    = do ret <- withCString path c_unloadObj
+    = do c_initLinker
+         ret <- withCString path c_unloadObj
          unless (ret /= 0) (fail $ "Unable to unload module: " ++ path)
 
 {-|
@@ -279,7 +291,8 @@ Beware that this function isn't type-safe in any way!
 -}
 loadFunction :: DynamicModule -> String -> IO a
 loadFunction dm functionName 
-    = do Ptr addr <- lookupSymbol (dm_qname dm) functionName
+    = do c_initLinker
+         Ptr addr <- lookupSymbol (dm_qname dm) functionName
          case addrToAny# addr of
                   (# hval #) -> return hval
 
@@ -300,7 +313,8 @@ Beware that this function isn't type-safe in any way!
 -}
 loadQualifiedFunction :: String -> IO a
 loadQualifiedFunction functionName
-    = do let qfunc = split '.' functionName
+    = do c_initLinker
+         let qfunc = split '.' functionName
          Ptr addr <- lookupSymbol (init qfunc) (last qfunc)
          case addrToAny# addr of
                   (# hval #) -> return hval
@@ -314,7 +328,8 @@ exception.
 -}
 resolveFunctions :: IO ()
 resolveFunctions 
-    = do ret <- c_resolveObjs
+    = do c_initLinker
+         ret <- c_resolveObjs
          when (ret == 0) (fail "Unable to resolve functions!")
 
 {-|


### PR DESCRIPTION
From [the patch notes](https://downloads.haskell.org/~ghc/7.10.1/docs/html/users_guide/release-7-10-1.html#idp5860656):

> The linker API is now thread-safe. The main user-facing impact of this change is that you must now call initLinker before calling loadObj or any of the other linker APIs.

Every FFI call now calls initLinker() first, which [is idempotent](https://github.com/ghc/ghc/blob/ghc-7.10/rts/Linker.c#L1657).

With this, the following example now works (on OS X):

Main.hs:
```haskell
import System.Plugins.DynamicLoader

main = do
	putStrLn "Loading module"
	mmodule <- loadModule "Plugin" (Just "tmp") Nothing
	print $ dm_path mmodule
```
Plugin.hs:
```haskell
module Plugin where

run = putStrLn "Hello world!"
```
Without this patch:
```
$ gdb ./test
...
Program received signal EXC_BAD_ACCESS, Could not access memory.
Reason: KERN_INVALID_ADDRESS at address: 0x0000000000002028
0x0000000101921a7e in lookupHashTable ()
(gdb) bt
#0  0x0000000101921a7e in lookupHashTable ()
#1  0x00000001019283b5 in loadOc ()
```
(For the record, this crash is because of `symhash` being `NULL` at https://github.com/ghc/ghc/blob/ghc-7.10/rts/Linker.c#L7160, `symhash` is supposed to be initialized in `initLinker_()`.)

With this patch:
```
$ ./test
Loading module
"tmp/Plugin.o"
```

I have tested this code with both ghc 7.8.3 and 7.10.1, however, I don't have 7.6 available to test with.